### PR TITLE
Integrate Swagger UI into 'API Details' page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,3 +4,4 @@ pygments: true
 safe: true
 baseurl: /ED-Developer-Hub/
 exclude: ['.ruby-version', 'node_modules', 'package.json', 'bower.json']
+swaggerurl: https://autoapi-ed.apps.cloud.gov/swagger/

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,12 @@
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="chrome=1">
+  <link rel="stylesheet" href="/ED-Developer-Hub/static/css/normalize.css">
+  <link rel="stylesheet" href="/ED-Developer-Hub/static/css/style.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!--[if lt IE 9]>
+  <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+  <![endif]-->
+
+  <!--[if IE]>
+  <link rel="stylesheet" href="/ED-Developer-Hub/static/css/for-ie-only.css">
+  <![endif]-->

--- a/_includes/swagger-section.html
+++ b/_includes/swagger-section.html
@@ -1,0 +1,5 @@
+<div class="swagger-section">
+  <div id="swagger-ui-container" class="swagger-ui-wrap">
+    <!-- The interactive API documentation will be injected here. -->
+  </div>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,19 +3,8 @@
 <!doctype html>
 <html>
 <head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="chrome=1">
+  {% include head.html %}
   <title>Department of Education - Developer Resources</title>
-  <link rel="stylesheet" href="/ED-Developer-Hub/static/css/normalize.css">
-  <link rel="stylesheet" href="/ED-Developer-Hub/static/css/style.css">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <!--[if lt IE 9]>
-  <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-  <![endif]-->
-
-  <!--[if IE]>
-  <link rel="stylesheet" href="/ED-Developer-Hub/static/css/for-ie-only.css">
-  <![endif]-->
 </head>
 <body>
   <!-- Google Tag Manager -->

--- a/_layouts/swagger-ui.html
+++ b/_layouts/swagger-ui.html
@@ -1,0 +1,86 @@
+---
+---
+<!doctype html>
+<html>
+<head>
+  {% include head.html %}
+
+  <link href='{{ site.baseurl }}static/vendor/swagger-ui/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
+
+  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/object-assign-pollyfill.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/jquery.slideto.min.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/jquery.wiggle.min.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/handlebars-4.0.5.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/lodash.min.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/backbone-min.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}static/vendor/swagger-ui/swagger-ui.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/jsoneditor.min.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/marked.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/swagger-oauth.js' type='text/javascript'></script>
+
+  <style>
+    html .swagger-section .swagger-ui-wrap {
+      min-width: auto;
+    }
+
+    /* Hide the heading title, as the page content will take care of it. */
+    html .swagger-section .info_title {
+      display: none;
+    }
+
+    /* Hide "[ BASE URL: / , API VERSION: 1.0 ]" details at the bottom. */
+    html .swagger-section .footer {
+      display: none;
+    }
+  </style>
+
+  <script>
+  var swaggerUi = new SwaggerUi({
+    url: '{{ site.swaggerurl }}',
+    dom_id: 'swagger-ui-container',
+    docExpansion: 'list'
+  });
+
+  swaggerUi.load();
+  </script>
+
+  <title>Department of Education - Developer Resources</title>
+</head>
+<body>
+  <header class="header cf" role="banner">
+      {% include header.html %}
+  </header>
+
+  <div class="wrap">
+    <div class="content">
+
+    <aside>
+    {% include nav.html %}
+    </aside>
+
+    <section class="main-content" role="main">
+      {{ content }}
+
+      {% comment %}
+        NOTE: {{ content }} must contain the following somewhere in it:
+
+        {% include swagger-section.html %}
+
+        If it doesn't, the swagger UI won't appear on the page.
+      {% endcomment %}
+    </section>
+
+    </div>
+  </div> <!--wrap-->
+
+    <footer class="footer cf" role="contentinfo">
+      <div class="wrap">
+        {% include footer.html %}
+      </div>
+    </footer>
+</body>
+</html>

--- a/pages/api-details.md
+++ b/pages/api-details.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: swagger-ui
 title: API Details
 nav: details
 permalink: /details/
@@ -11,6 +11,6 @@ permalink: /details/
 
 _This site is a pilot project.  If you have feedback or questions, [let us know](https://github.com/18F/ED-Developer-Hub/issues)!_
 
-
+{% include swagger-section.html %}
 
 ...


### PR DESCRIPTION
**Note:** This PR builds upon https://github.com/18F/ED-Developer-Hub/pull/10, which should be merged first. The feature was split into two separate PRs to make code review easier.

This integrates the Swagger UI into the API Details page, fixing https://github.com/18F/ED-Developer-Hub/issues/9:

> <img width="660" alt="screen shot 2016-08-29 at 9 54 17 am" src="https://cloud.githubusercontent.com/assets/124687/18053662/9589ce98-6dce-11e6-8a4b-3c1c1f52a489.png">
## Notes
- The JS for the rest of the site isn't added to the 'API Details' page because its version of underscore seems to conflict with the one Swagger UI uses.  If we really want any common JS from the rest of the site to be loaded, we may eventually need to put Swagger UI into an iframe or something. 😞 
